### PR TITLE
Fix remaining copywrite for PIVX issue

### DIFF
--- a/src/clientversion.h
+++ b/src/clientversion.h
@@ -38,7 +38,7 @@
 #define DO_STRINGIZE(X) #X
 
 //! Copyright string used in Windows .rc files
-#define COPYRIGHT_STR "2009-" STRINGIZE(COPYRIGHT_YEAR) " The Bitcoin Core Developers, 2014-" STRINGIZE(COPYRIGHT_YEAR) " The Dash Core Developers, 2015-" STRINGIZE(COPYRIGHT_YEAR) " The InstaCash Core Developers"
+#define COPYRIGHT_STR "2009-" STRINGIZE(COPYRIGHT_YEAR) " The Bitcoin Core Developers, 2014-" STRINGIZE(COPYRIGHT_YEAR) " The Dash Core Developers, 2015-"  STRINGIZE(COPYRIGHT_YEAR) " The PIVX Core Developers, 2015-" STRINGIZE(COPYRIGHT_YEAR) " The Instacash Core Developers"
 
 /**
  * instacashd-res.rc includes this file, but it cannot cope with real c++ code.


### PR DESCRIPTION
This copywrite the replace script couldn't do, but the search and replace initially done removed it, so as per our notice this needs to be fixed.  GUI splash screen / help > about, and other places. https://github.com/insta-cash/instacash/issues/20 in regards to https://github.com/insta-cash/instacash/issues/1